### PR TITLE
Updated page content based on feedback. Tool page is now full-width, no sidebar.

### DIFF
--- a/index_ubc.html
+++ b/index_ubc.html
@@ -417,280 +417,116 @@ var js_errors = {"wpajaxurl":"https:\/\/lthub.ubc.ca\/wp-admin\/admin-ajax.php",
         </div><!-- /navbar-inner -->
     </div><!-- /navbar -->
 
+	<div id="container" class="expand">
 
-	<div id="container" class="expand" >
-
-		<div class="breadcrumb expand" itemprop="breadcrumb">
-            <span class="trail-begin"><a href="https://lthub.ubc.ca" title="Teaching with Technology" rel="home" class="trail-begin">Home</a></span>
-            <span class="divider">»</span>
-            <a href="https://lthub.ubc.ca/guides/" title="Tool Guides">Tool Guides</a>
-            <span class="divider">»</span>
-            <span class="trail-end">Canvas</span>
-        </div>
+		<div class="breadcrumb expand" itemprop="breadcrumb"><span class="trail-begin"><a href="https://elearning5.sites.olt.ubc.ca" title="Teaching with Technology" rel="home" class="trail-begin">Home</a></span> <span class="divider">»</span> <a href="https://elearning5.sites.olt.ubc.ca/guides/" title="Tool Guides">Tool Guides</a> <span class="divider">»</span> <a href="https://elearning5.sites.olt.ubc.ca/guides/zoom-instructor-guide/" title="Zoom Instructor Guide">Zoom Instructor Guide</a> <span class="divider">»</span> <span class="trail-end">Closed Captioning for Zoom</span></div>
 
         <div class="expand row-fluid" role="main">
-	        <div id="primary-secondary" class="sidebar aside  span3">
-		        <div id="primary">
-			        <div id="olt-subpages-navigation-widget-3" class="widget widget_subpages_navigation widget-widget_subpages_navigation">
-                        <div class="widget-wrap widget-inside">
-                            <h3 class="widget-title">Tool Guides</h3>
-		                    <div class="accordion sidenav simple subpages-navi subpages-navi-widget subpages-navi-exclusive subpages-navi-collapsible subpages-navi-auto-expand" id="parent-olt-subpages-navigation-widget-30">
-		                        <div class='single'>
-                                    <a href='https://lthub.ubc.ca/guides/all/'><div class='ubc7-arrow right-arrow'></div> All Guides (A-Z)</a>
-                                </div>
-                                <div class='single'>
-                                    <a href='https://lthub.ubc.ca/guides/campus-media-capture/'><div class='ubc7-arrow right-arrow'></div> Campus Media Capture</a>
-                                </div>
-                                <div class='single'>
-                                    <a href='https://lthub.ubc.ca/guides/camtasia/'><div class='ubc7-arrow right-arrow'></div> Camtasia</a>
-                                </div>
 
-                                <div class='accordion-group'>
-                                    <div class='accordion-heading subpages-navi-node supages-navi-level-0 opened'>
-                                        <a class='accordion-toggle' data-toggle='collapse' data-parent='#parent-olt-subpages-navigation-widget-30' href='#accordion-olt-subpages-navigation-widget-33782' role='button' aria-haspopup='true' aria-expanded='true'  aria-label='expand Canvas menu'><div class='ubc7-arrow down-arrow' aria-hidden='true'></div></a>
-                                        <a class='link opened' href='https://lthub.ubc.ca/guides/canvas/'>Canvas</a>
+            <div id="content" class="hfeed content  span12">
+
+			    <div id="post-10114" class="hentry page draft post-1 odd author-lse72">
+
+				    <h1 class="page-title entry-title">Closed Captioning for Zoom</h1>
+
+                    <div class="entry-content">
+
+
+                        <div class="guide">
+
+                            <div class="intro">
+                                This page enables closed captioning for live Zoom sessions. For help with using Zoom generally, check out UBC’s <a href="https://elearning5.sites.olt.ubc.ca/guides/zoom-instructor-guide/" rel="noopener noreferrer" target="_blank">Zoom instructor guide</a>.
+                            </div>
+
+                            <h2 class="heading-divider">How do I add closed captioning to Zoom?</h2>
+                            <p>Once you start a Zoom session, you will copy and paste an identifier for your session (called a token) in the form below. This token tells the closed captioning tool which Zoom session should receive the captions it creates. Then you can start the captioning and students will be able to read whatever your microphones hears in real time.</p>
+
+                            <div id="random-accordion-id-254" class="accordion-shortcode accordion ">
+                                <div class="accordion-group">
+                                    <div class="accordion-heading">
+                                        <a href="#use-closed-captioning-during-a-0" class="accordion-toggle " data-toggle="collapse" data-parent="#random-accordion-id-254">&gt; Use closed captioning during a real-time lecture</a>
                                     </div>
-                                    <div id='accordion-olt-subpages-navigation-widget-33782' class='accordion-body collapse in'>
-                                        <div class='accordion-inner'>
-                                            <a href='https://lthub.ubc.ca/guides/canvas/student-timezones-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> Student Timezones Instructor Guide</a>
-                                            <a href='https://lthub.ubc.ca/guides/canvas/faculty-example-robert-russo/'><div class='ubc7-arrow right-arrow'></div> Faculty Example: An Interactive and User-Friendly Experience for Students</a>
-                                            <a href='https://lthub.ubc.ca/guides/canvas/faculty-example-intuitive-system-to-learn-for-mining-engineering-students/'><div class='ubc7-arrow right-arrow'></div> Faculty Example: Intuitive System to Learn for Mining Engineering Students</a>
-                                            <a href='https://lthub.ubc.ca/guides/canvas/canvas-faqs/'><div class='ubc7-arrow right-arrow'></div> Canvas FAQ</a>
-                                            <a href='https://lthub.ubc.ca/guides/canvas/privacy/'><div class='ubc7-arrow right-arrow'></div> Canvas &amp; Privacy</a>
-                                        </div><!-- end_inner -->
-                                    </div><!-- end_body -->
-                                </div>
-
-                                <div class='single'>
-                                    <a href='https://lthub.ubc.ca/guides/canvas-catalog/'><div class='ubc7-arrow right-arrow'></div> Canvas Catalog</a>
-                                </div>
-
-                                <div class='single'>
-                                    <a href='https://lthub.ubc.ca/guides/clas/'><div class='ubc7-arrow right-arrow'></div> CLAS</a>
-                                </div>
-
-                                <div class='single'>
-                                    <a href='https://lthub.ubc.ca/guides/collaborate-ultra-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> Collaborate Ultra Instructor Guide</a>
-                                </div>
-
-                                <div class='accordion-group'>
-                                    <div class='accordion-heading subpages-navi-node supages-navi-level-0'>
-                                        <a class='accordion-toggle' data-toggle='collapse' data-parent='#parent-olt-subpages-navigation-widget-30' href='#accordion-olt-subpages-navigation-widget-33676' role='button' aria-haspopup='true' aria-expanded='true'  aria-label='expand ComPAIR menu'><div class='ubc7-arrow down-arrow' aria-hidden='true'></div></a>
-                                        <a class='link' href='https://lthub.ubc.ca/guides/compair/'>ComPAIR</a>
+                                    <div id="use-closed-captioning-during-a-0" class="accordian-shortcode-content accordion-body collapse in">
+                                        <div class="accordion-inner">
+                                            <p></p>
+                                            <div class="row-fluid">
+                                                <div class="span7">
+                                                    <h3>Use closed captioning during a real-time lecture</h3>
+                                                    <ol>
+                                                        <li>You will need to keep this page open, as it contains the tool that captions your audio. Please make sure this page is open in a browser window you won't accidentally close during your lecture.</li>
+                                                        <li>In your active Zoom session, click the <strong>Closed Captioning</strong> icon at the bottom of your screen and select <strong>Copy the API token</strong>.</li>
+                                                        <li><strong>Paste</strong> the token below and set the <strong>language</strong> you'll be speaking in.</li>
+                                                        <li>Click <strong>Start</strong> below when you are ready. Give your browser permission to access your microphone, and the captioning will begin.</li>
+                                                        <li>Click <strong>Stop</strong> to pause or end captioning. When you end the Zoom session, the full transcript will download automatically to your computer as a text file, in a folder created for the session.</li>
+                                                    </ol>
+                                                </div>
+                                                <div class="span5 tip-box">
+                                                    <h4><i class="icon-hand-right"></i> Tips</h4>
+                                                    <ul>
+                                                        <li><strong>Muting your microphone in Zoom will not mute your microphone for the captioning tool</strong>. To "mute" captioning, you will need to click stop on this page.</li>
+                                                        <li><strong>The captioning tool will only caption audio heard by your microphone</strong>. It will not caption other participants, unless you use speakers so your microphone hears them. (But using speakers is not recommended, since it is likely to create audio problems.)</li>
+                                                        <li><strong>Students can turn captioning on by clicking the arrow next to the Closed Captioning icon, and selecting Show Subtitle</strong>. Note there may be a slight delay between you starting the captioning and this arrow appearing.</li>
+                                                    </ul>
+                                                </div>
+                                            </div>
+                                            <p></p>
+                                        </div>
                                     </div>
-                                    <div id='accordion-olt-subpages-navigation-widget-33676' class='accordion-body collapse'>
-                                        <div class='accordion-inner'>
-                                            <a href='https://lthub.ubc.ca/guides/compair/pilot/'><div class='ubc7-arrow right-arrow'></div> ComPAIR Pilot</a>
-                                        </div><!-- end_inner -->
-                                    </div><!-- end_body -->
                                 </div>
+                            </div>
 
-                                <div class='single'>
-                                    <a href='https://lthub.ubc.ca/guides/crowdmark/'><div class='ubc7-arrow right-arrow'></div> Crowdmark</a>
-                                </div>
+                            <div id="real-time-audio-transcription-for-zoom">
+                                <h3>Zoom closed captioning tool</h3>
 
-                                <div class='accordion-group'>
-                                    <div class='accordion-heading subpages-navi-node supages-navi-level-0'>
-                                        <a class='accordion-toggle' data-toggle='collapse' data-parent='#parent-olt-subpages-navigation-widget-30' href='#accordion-olt-subpages-navigation-widget-3188' role='button' aria-haspopup='true' aria-expanded='true'  aria-label='expand edX Edge menu'><div class='ubc7-arrow down-arrow' aria-hidden='true'></div></a>
-                                        <a class='link' href='https://lthub.ubc.ca/guides/edx/'>edX Edge</a>
+                                <div id="error" class="isa_error"></div>
+                                <div class="row">
+                                    <div class="col">
+                                        <label>ZOOM CC API Token:</label>
+                                        <input type="password" id="zoom_api_token" placeholder="ZOOM API Token" value="" />
                                     </div>
-                                <div id='accordion-olt-subpages-navigation-widget-3188' class='accordion-body collapse'>
-                                    <div class='accordion-inner'>
-                                        <a href='https://lthub.ubc.ca/guides/edx/astronomy-311-example/'><div class='ubc7-arrow right-arrow'></div> Faculty Example: Astronomy 311</a>
-                                        <a href='https://lthub.ubc.ca/guides/edx/research-methods-example/'><div class='ubc7-arrow right-arrow'></div> Faculty Example: Research Methods Course</a>
-                                        <a href='https://lthub.ubc.ca/guides/edx/use-cwls-with-edx/'><div class='ubc7-arrow right-arrow'></div> Use CWLs with edX</a>
-                                        <a href='https://lthub.ubc.ca/guides/edx/embed-edx-content/'><div class='ubc7-arrow right-arrow'></div> Embed edX content in LMS</a>
-                                    </div><!-- end_inner -->
-                                </div><!-- end_body -->
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/gradescope/'><div class='ubc7-arrow right-arrow'></div> Gradescope</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/iclicker-cloud-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> iClicker Cloud Instructor Guide</a>
-                            </div>
-
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/iclicker-cloud-student-guide/'><div class='ubc7-arrow right-arrow'></div> iClicker Cloud Student Guide</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/ipeer/'><div class='ubc7-arrow right-arrow'></div> iPeer</a>
-                            </div>
-
-                            <div class='accordion-group'>
-                                <div class='accordion-heading subpages-navi-node supages-navi-level-0'>
-                                    <a class='accordion-toggle' data-toggle='collapse' data-parent='#parent-olt-subpages-navigation-widget-30' href='#accordion-olt-subpages-navigation-widget-3424' role='button' aria-haspopup='true' aria-expanded='true'  aria-label='expand Kaltura menu'><div class='ubc7-arrow down-arrow' aria-hidden='true'></div></a>
-                                    <a class='link' href='https://lthub.ubc.ca/guides/kaltura/'>Kaltura</a>
+                                    <div class="col">
+                                        <label>Language: </label>
+                                        <select id="language">
+                                            <optgroup label="English">
+                                                <option value="en-US">US English (en-US)</option>
+                                                <option value="en-AU">Australian English (en-AU)</option>
+                                                <option value="en-GB">British English (en-GB)</option>
+                                            </optgroup>
+                                            <optgroup label="French">
+                                                <option value="fr-CA">Canadian French (fr-CA)</option>
+                                                <option value="fr-FR">French (fr-FR)</option>
+                                            </optgroup>
+                                            <optgroup label="Spanish">
+                                                <option value="es-US">US Spanish (es-US)</option>
+                                            </optgroup>
+                                        </select>
+                                    </div>
                                 </div>
-                                <div id='accordion-olt-subpages-navigation-widget-3424' class='accordion-body collapse'>
-                                    <div class='accordion-inner'>
-                                        <a href='https://lthub.ubc.ca/guides/kaltura/faculty-example-using-kaltura-to-share-instructional-videos-with-students/'><div class='ubc7-arrow right-arrow'></div> Faculty Example: Using Kaltura to Share Instructional Videos with Students</a>
-                                    </div><!-- end_inner -->
-                                </div><!-- end_body -->
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/lightboard/'><div class='ubc7-arrow right-arrow'></div> Lightboard</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/lockdown-browser/'><div class='ubc7-arrow right-arrow'></div> LockDown Browser</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/course-reserves-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> LOCR</a>
-                            </div>
-
-                            <div class='accordion-group'>
-                                <div class='accordion-heading subpages-navi-node supages-navi-level-0'>
-                                    <a class='accordion-toggle' data-toggle='collapse' data-parent='#parent-olt-subpages-navigation-widget-30' href='#accordion-olt-subpages-navigation-widget-35815' role='button' aria-haspopup='true' aria-expanded='true'  aria-label='expand Mattermost menu'><div class='ubc7-arrow down-arrow' aria-hidden='true'></div></a>
-                                    <a class='link' href='https://lthub.ubc.ca/guides/mattermost/'>Mattermost</a>
+                                <textarea id="transcript" placeholder="Press Start and speak into your mic" rows="5" readonly="readonly"></textarea>
+                                <div class="row">
+                                    <div class="col">
+                                        <button id="start-button" class="button-xl" title="Start Transcription">
+                                            <i class="fa fa-microphone"></i> Start
+                                        </button>
+                                        <button id="stop-button" class="button-xl" title="Stop Transcription" disabled="true">
+                                            <i class="fa fa-stop-circle"></i> Stop
+                                        </button>
+                                        <button id="reset-button" class="button-xl button-secondary" title="Clear Transcript">Clear Transcript</button>
+                                    </div>
+                                    <div class="col"></div>
                                 </div>
-                                <div id='accordion-olt-subpages-navigation-widget-35815' class='accordion-body collapse'>
-                                    <div class='accordion-inner'>
-                                        <a href='https://lthub.ubc.ca/guides/mattermost/mattermost-pilot/'><div class='ubc7-arrow right-arrow'></div> Mattermost Pilot</a>
-                                    </div><!-- end_inner -->
-                                </div><!-- end_body -->
                             </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/microsoft-onedrive-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> Microsoft OneDrive Instructor Guide</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/microsoft-teams-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> Microsoft Teams Instructor Guide</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/one-button-studio/'><div class='ubc7-arrow right-arrow'></div> One-Button Studio</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/peerscholar/'><div class='ubc7-arrow right-arrow'></div> peerScholar</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/peerwise/'><div class='ubc7-arrow right-arrow'></div> PeerWise</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/piazza/'><div class='ubc7-arrow right-arrow'></div> Piazza</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/proctorio-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> Proctorio Instructor Guide</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/survey-tool/'><div class='ubc7-arrow right-arrow'></div> Qualtrics</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/respondus-quiz/'><div class='ubc7-arrow right-arrow'></div> Respondus Quiz</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/respondus-studymate/'><div class='ubc7-arrow right-arrow'></div> Respondus Studymate</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/snagit/'><div class='ubc7-arrow right-arrow'></div> Snagit</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/turnitin/'><div class='ubc7-arrow right-arrow'></div> Turnitin</a>
-                            </div>
-                            <div class='single'>
-                                <a href='https://lthub.ubc.ca/guides/ubc-blogs/'><div class='ubc7-arrow right-arrow'></div> UBC Blogs</a>
-                            </div>
-
-                            <div class='accordion-group'>
-                                <div class='accordion-heading subpages-navi-node supages-navi-level-0'>
-                                    <a class='accordion-toggle' data-toggle='collapse' data-parent='#parent-olt-subpages-navigation-widget-30' href='#accordion-olt-subpages-navigation-widget-3456' role='button' aria-haspopup='true' aria-expanded='true'  aria-label='expand UBC Wiki menu'><div class='ubc7-arrow down-arrow' aria-hidden='true'></div></a>
-                                    <a class='link' href='https://lthub.ubc.ca/guides/ubc-wiki/'>UBC Wiki</a>
-                                </div>
-                                <div id='accordion-olt-subpages-navigation-widget-3456' class='accordion-body collapse'>
-                                    <div class='accordion-inner'>
-                                        <a href='https://lthub.ubc.ca/guides/ubc-wiki/blended-learning-example/'><div class='ubc7-arrow right-arrow'></div> Faculty Example: Wiki for Blended Learning Environment</a>
-                                    </div><!-- end_inner -->
-                                </div><!-- end_body -->
-                            </div>
-
-                            <div class='accordion-group'>
-                                <div class='accordion-heading subpages-navi-node supages-navi-level-0'>
-                                    <a class='accordion-toggle' data-toggle='collapse' data-parent='#parent-olt-subpages-navigation-widget-30' href='#accordion-olt-subpages-navigation-widget-3436' role='button' aria-haspopup='true' aria-expanded='true'  aria-label='expand VideoScribe menu'><div class='ubc7-arrow down-arrow' aria-hidden='true'></div></a>
-                                    <a class='link' href='https://lthub.ubc.ca/guides/videoscribe/'>VideoScribe</a>
-                                </div>
-                            <div id='accordion-olt-subpages-navigation-widget-3436' class='accordion-body collapse'>
-                                <div class='accordion-inner'>
-                                    <a href='https://lthub.ubc.ca/guides/videoscribe/request-license/'><div class='ubc7-arrow right-arrow'></div> Request a VideoScribe License</a>
-                                </div><!-- end_inner -->
-                            </div><!-- end_body -->
                         </div>
-                        <div class='single'>
-                            <a href='https://lthub.ubc.ca/guides/webwork-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> Webwork Instructor Guide</a>
-                        </div>
-                        <div class='single'>
-                            <a href='https://lthub.ubc.ca/guides/zoom-instructor-guide/'><div class='ubc7-arrow right-arrow'></div> Zoom Instructor Guide</a>
-                        </div>
-                    </div>
-		        </div>
-            </div>
+					</div><!-- .entry-content -->
 
-		</div><!-- #primary -->
+				    <p class="entry-meta"><span class="page-meta"></span></p>
 
+                </div><!-- .hentry -->
 
-	</div><!-- #primary-secondary .aside -->
+	        </div><!-- .content .hfeed -->
 
-
-	<div id="content" class="hfeed content  span9">
-
-        <!-- CIC START HERE -->
-        <div id="real-time-audio-transcription-for-zoom">
-            <h1>Real-time Audio Transcription  for Zoom</h1>
-            <p class="small-caps">Using the <a href="https://aws.amazon.com/transcribe/">Amazon Transcribe</a> WebSocket API</p>
-            Instructions:
-            <ol>
-                <li>Launch a new Zoom meeting.</li>
-                <li>In the meeting room task bar click on the 'Closed Caption' icon and click 'Copy the API token' to copy the API token to clipboard.</li>
-                <li>Paste the API token below in the 'ZOOM CC API Token' field.</li>
-                <li>Select a language in the 'Language' field if needed.</li>
-                <li>Click the 'Start' button when you are ready to start recording audio to be transcribed. This will prompt a browser response to grant access to your microphone, click 'Allow'.</li>
-            </ol>
-            <p><strong>Muting your microphone in Zoom will not mute your microphone in this tool.</strong> You will still generate captions that will be sent to the Zoom meeting unless you also click 'Stop' to stop recording below.</p>
-            <p>This tool will only generate captions for what you say. It will not generate captions for student questions and discussions unless they are picked up by your microphone (not recommended).</p>
-            <hr/>
-            <div id="error" class="isa_error"></div>
-            <div class="row">
-                <div class="col">
-                    <label>ZOOM CC API Token:</label>
-                    <input type="password" id="zoom_api_token" placeholder="ZOOM API Token" value="" />
-                </div>
-                <div class="col">
-                    <label>Language: </label>
-                    <select id="language">
-                        <optgroup label="English">
-                            <option value="en-US">US English (en-US)</option>
-                            <option value="en-AU">Australian English (en-AU)</option>
-                            <option value="en-GB">British English (en-GB)</option>
-                        </optgroup>
-                        <optgroup label="French">
-                            <option value="fr-CA">Canadian French (fr-CA)</option>
-                            <option value="fr-FR">French (fr-FR)</option>
-                        </optgroup>
-                        <optgroup label="Spanish">
-                            <option value="es-US">US Spanish (es-US)</option>
-                        </optgroup>
-                    </select>
-                </div>
-            </div>
-            <textarea id="transcript" placeholder="Press Start and speak into your mic" rows="5" readonly="readonly"></textarea>
-            <div class="row">
-                <div class="col">
-                    <button id="start-button" class="button-xl" title="Start Transcription">
-                        <i class="fa fa-microphone"></i> Start
-                    </button>
-                    <button id="stop-button" class="button-xl" title="Stop Transcription" disabled="true">
-                        <i class="fa fa-stop-circle"></i> Stop
-                    </button>
-                    <button id="reset-button" class="button-xl button-secondary" title="Clear Transcript">Clear Transcript</button>
-                </div>
-                <div class="col"></div>
-            </div>
-        </div>
-
-        <!-- CIC END HERE -->
-
-	</div><!-- .content .hfeed -->
-
-</div>
-
-</div><!-- #body-container -->
+		</div>
+	</div>
 
 
 <!-- CLF Footer -->


### PR DESCRIPTION
Tool now begins on [line 478](https://github.com/UBC-CIC/amazon-transcribe-captions-for-zoom/compare/master...richardtape:ubc-clf-content-full-page-tool?expand=1#diff-0d055307953e0eff816e10c9ade66eabR478).