### PR TITLE
Added main menu item.

### DIFF
--- a/index_ubc.html
+++ b/index_ubc.html
@@ -357,6 +357,7 @@ var js_errors = {"wpajaxurl":"https:\/\/lthub.ubc.ca\/wp-admin\/admin-ajax.php",
                                     <li id="menu-item-8496" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8496"><a href="https://lthub.ubc.ca/guides/collaborate-ultra-instructor-guide/">Collaborate Ultra Instructor Guide</a></li>
                                     <li id="menu-item-8854" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8854"><a href="https://lthub.ubc.ca/guides/proctorio-instructor-guide/">Proctorio Instructor Guide</a></li>
                                     <li id="menu-item-8469" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-8469"><a href="https://lthub.ubc.ca/guides/zoom-instructor-guide/">Zoom Instructor Guide</a></li>
+                                    <li id="menu-item-9999" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-9999"><a href="https://lthub.ubc.ca/guides/closed-captioning-for-zoom/">Closed Captioning For Zoom</a></li>
                                     <li id="menu-item-1238" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-1238"><a href="https://lthub.ubc.ca/guides/all/">All Guides (A-Z)</a></li>
                                 </ul>
                             </div>


### PR DESCRIPTION
Tool now begins on [line 478](https://github.com/UBC-CIC/amazon-transcribe-captions-for-zoom/compare/master...richardtape:ubc-clf-content-full-page-tool?expand=1#diff-0d055307953e0eff816e10c9ade66eabR478).